### PR TITLE
check for time_abort in SimplexSolver (#149)

### DIFF
--- a/src/org/ojalgo/optimisation/linear/SimplexSolver.java
+++ b/src/org/ojalgo/optimisation/linear/SimplexSolver.java
@@ -490,7 +490,9 @@ public final class SimplexSolver extends LinearSolver {
             this.logDebugTableau("Initial Tableau");
         }
 
-        while (this.needsAnotherIteration()) {
+        this.resetIterationsCount();
+
+        while (this.isIterationAllowed() && this.needsAnotherIteration()) {
 
             this.performIteration(myPoint);
 

--- a/src/org/ojalgo/optimisation/linear/SimplexSolver.java
+++ b/src/org/ojalgo/optimisation/linear/SimplexSolver.java
@@ -496,6 +496,8 @@ public final class SimplexSolver extends LinearSolver {
 
             this.performIteration(myPoint);
 
+            this.incrementIterationsCount();
+
             if (this.isDebug() && this.isTableauPrintable()) {
                 this.logDebugTableau("Tableau Iteration");
             }

--- a/test/org/ojalgo/optimisation/linear/CommonsMathSimplexSolverTest.java
+++ b/test/org/ojalgo/optimisation/linear/CommonsMathSimplexSolverTest.java
@@ -118,6 +118,8 @@ public class CommonsMathSimplexSolverTest extends OptimisationLinearTests {
         public double getConstant() {
             return myConstant;
         }
+        
+        public Optimisation.Options getOptions() { return myModel.options; }
 
         public MultiaryFunction<Double> getObjectiveFunction() {
             return myModel.objective().toFunction();
@@ -718,6 +720,114 @@ public class CommonsMathSimplexSolverTest extends OptimisationLinearTests {
         }
 
     }
+    
+    private final class LargeModelFactory {
+
+        final double[] objective = new double[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+        
+        Collection<LinearConstraint> generateConstraints() {
+            final Collection<LinearConstraint> constraints = new ArrayList<>();
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x0 + x1 + x2 + x3 - x12 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 - x13 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 >= 49"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x0 + x1 + x2 + x3 >= 42"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x14 + x15 + x16 + x17 - x26 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 - x27 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x14 + x15 + x16 + x17 - x12 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 - x13 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x28 + x29 + x30 + x31 - x40 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 - x41 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 >= 49"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x28 + x29 + x30 + x31 >= 42"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x42 + x43 + x44 + x45 - x54 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 - x55 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x42 + x43 + x44 + x45 - x40 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 - x41 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x56 + x57 + x58 + x59 - x68 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x60 + x61 + x62 + x63 + x64 + x65 + x66 + x67 - x69 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x60 + x61 + x62 + x63 + x64 + x65 + x66 + x67 >= 51"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x56 + x57 + x58 + x59 >= 44"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x70 + x71 + x72 + x73 - x82 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x74 + x75 + x76 + x77 + x78 + x79 + x80 + x81 - x83 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x70 + x71 + x72 + x73 - x68 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x74 + x75 + x76 + x77 + x78 + x79 + x80 + x81 - x69 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x84 + x85 + x86 + x87 - x96 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x88 + x89 + x90 + x91 + x92 + x93 + x94 + x95 - x97 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x88 + x89 + x90 + x91 + x92 + x93 + x94 + x95 >= 51"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x84 + x85 + x86 + x87 >= 44"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x98 + x99 + x100 + x101 - x110 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x102 + x103 + x104 + x105 + x106 + x107 + x108 + x109 - x111 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x98 + x99 + x100 + x101 - x96 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x102 + x103 + x104 + x105 + x106 + x107 + x108 + x109 - x97 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x112 + x113 + x114 + x115 - x124 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x116 + x117 + x118 + x119 + x120 + x121 + x122 + x123 - x125 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x116 + x117 + x118 + x119 + x120 + x121 + x122 + x123 >= 49"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x112 + x113 + x114 + x115 >= 42"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x126 + x127 + x128 + x129 - x138 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x130 + x131 + x132 + x133 + x134 + x135 + x136 + x137 - x139 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x126 + x127 + x128 + x129 - x124 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x130 + x131 + x132 + x133 + x134 + x135 + x136 + x137 - x125 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x140 + x141 + x142 + x143 - x152 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x144 + x145 + x146 + x147 + x148 + x149 + x150 + x151 - x153 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x144 + x145 + x146 + x147 + x148 + x149 + x150 + x151 >= 59"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x140 + x141 + x142 + x143 >= 42"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x154 + x155 + x156 + x157 - x166 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x158 + x159 + x160 + x161 + x162 + x163 + x164 + x165 - x167 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x154 + x155 + x156 + x157 - x152 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x158 + x159 + x160 + x161 + x162 + x163 + x164 + x165 - x153 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x83 + x82 - x168 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x111 + x110 - x169 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x170 - x182 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x171 - x183 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x172 - x184 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x173 - x185 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x174 - x186 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x175 + x176 - x187 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x177 - x188 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x178 - x189 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x179 - x190 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x180 - x191 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x181 - x192 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x170 - x26 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x171 - x27 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x172 - x54 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x173 - x55 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x174 - x168 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x177 - x169 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x178 - x138 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x179 - x139 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x180 - x166 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x181 - x167 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x193 - x205 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x194 - x206 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x195 - x207 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x196 - x208 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x197 - x209 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x198 + x199 - x210 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x200 - x211 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x201 - x212 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x202 - x213 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x203 - x214 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x204 - x215 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x193 - x182 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x194 - x183 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x195 - x184 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x196 - x185 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x197 - x186 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x198 + x199 - x187 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x200 - x188 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x201 - x189 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x202 - x190 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x203 - x191 = 0"));
+            constraints.add(CommonsMathSimplexSolverTest.this.equationFromString(objective.length, "x204 - x192 = 0"));
+            return constraints;
+        }
+        
+    }
 
     @Test
     public void testDegeneracy() {
@@ -764,107 +874,10 @@ public class CommonsMathSimplexSolverTest extends OptimisationLinearTests {
 
     @Test
     public void testLargeModel() {
-        final double[] objective = new double[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 12, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+        final LargeModelFactory lmf = new LargeModelFactory();
 
-        final LinearObjectiveFunction f = new LinearObjectiveFunction(objective, 0);
-        final Collection<LinearConstraint> constraints = new ArrayList<>();
-        constraints.add(this.equationFromString(objective.length, "x0 + x1 + x2 + x3 - x12 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 - x13 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 >= 49"));
-        constraints.add(this.equationFromString(objective.length, "x0 + x1 + x2 + x3 >= 42"));
-        constraints.add(this.equationFromString(objective.length, "x14 + x15 + x16 + x17 - x26 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 - x27 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x14 + x15 + x16 + x17 - x12 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25 - x13 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x28 + x29 + x30 + x31 - x40 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 - x41 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x32 + x33 + x34 + x35 + x36 + x37 + x38 + x39 >= 49"));
-        constraints.add(this.equationFromString(objective.length, "x28 + x29 + x30 + x31 >= 42"));
-        constraints.add(this.equationFromString(objective.length, "x42 + x43 + x44 + x45 - x54 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 - x55 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x42 + x43 + x44 + x45 - x40 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x46 + x47 + x48 + x49 + x50 + x51 + x52 + x53 - x41 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x56 + x57 + x58 + x59 - x68 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x60 + x61 + x62 + x63 + x64 + x65 + x66 + x67 - x69 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x60 + x61 + x62 + x63 + x64 + x65 + x66 + x67 >= 51"));
-        constraints.add(this.equationFromString(objective.length, "x56 + x57 + x58 + x59 >= 44"));
-        constraints.add(this.equationFromString(objective.length, "x70 + x71 + x72 + x73 - x82 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x74 + x75 + x76 + x77 + x78 + x79 + x80 + x81 - x83 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x70 + x71 + x72 + x73 - x68 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x74 + x75 + x76 + x77 + x78 + x79 + x80 + x81 - x69 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x84 + x85 + x86 + x87 - x96 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x88 + x89 + x90 + x91 + x92 + x93 + x94 + x95 - x97 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x88 + x89 + x90 + x91 + x92 + x93 + x94 + x95 >= 51"));
-        constraints.add(this.equationFromString(objective.length, "x84 + x85 + x86 + x87 >= 44"));
-        constraints.add(this.equationFromString(objective.length, "x98 + x99 + x100 + x101 - x110 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x102 + x103 + x104 + x105 + x106 + x107 + x108 + x109 - x111 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x98 + x99 + x100 + x101 - x96 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x102 + x103 + x104 + x105 + x106 + x107 + x108 + x109 - x97 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x112 + x113 + x114 + x115 - x124 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x116 + x117 + x118 + x119 + x120 + x121 + x122 + x123 - x125 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x116 + x117 + x118 + x119 + x120 + x121 + x122 + x123 >= 49"));
-        constraints.add(this.equationFromString(objective.length, "x112 + x113 + x114 + x115 >= 42"));
-        constraints.add(this.equationFromString(objective.length, "x126 + x127 + x128 + x129 - x138 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x130 + x131 + x132 + x133 + x134 + x135 + x136 + x137 - x139 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x126 + x127 + x128 + x129 - x124 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x130 + x131 + x132 + x133 + x134 + x135 + x136 + x137 - x125 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x140 + x141 + x142 + x143 - x152 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x144 + x145 + x146 + x147 + x148 + x149 + x150 + x151 - x153 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x144 + x145 + x146 + x147 + x148 + x149 + x150 + x151 >= 59"));
-        constraints.add(this.equationFromString(objective.length, "x140 + x141 + x142 + x143 >= 42"));
-        constraints.add(this.equationFromString(objective.length, "x154 + x155 + x156 + x157 - x166 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x158 + x159 + x160 + x161 + x162 + x163 + x164 + x165 - x167 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x154 + x155 + x156 + x157 - x152 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x158 + x159 + x160 + x161 + x162 + x163 + x164 + x165 - x153 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x83 + x82 - x168 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x111 + x110 - x169 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x170 - x182 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x171 - x183 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x172 - x184 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x173 - x185 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x174 - x186 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x175 + x176 - x187 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x177 - x188 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x178 - x189 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x179 - x190 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x180 - x191 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x181 - x192 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x170 - x26 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x171 - x27 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x172 - x54 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x173 - x55 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x174 - x168 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x177 - x169 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x178 - x138 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x179 - x139 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x180 - x166 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x181 - x167 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x193 - x205 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x194 - x206 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x195 - x207 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x196 - x208 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x197 - x209 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x198 + x199 - x210 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x200 - x211 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x201 - x212 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x202 - x213 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x203 - x214 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x204 - x215 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x193 - x182 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x194 - x183 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x195 - x184 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x196 - x185 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x197 - x186 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x198 + x199 - x187 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x200 - x188 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x201 - x189 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x202 - x190 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x203 - x191 = 0"));
-        constraints.add(this.equationFromString(objective.length, "x204 - x192 = 0"));
+        final LinearObjectiveFunction f = new LinearObjectiveFunction(lmf.objective, 0);
+        final Collection<LinearConstraint> constraints = lmf.generateConstraints();
 
         final SimplexSolver solver = new SimplexSolver();
         final PointValuePair solution = solver.optimize(f, constraints, GoalType.MINIMIZE, true);
@@ -1221,6 +1234,20 @@ public class CommonsMathSimplexSolverTest extends OptimisationLinearTests {
             lhs[index] = value;
         }
         return new LinearConstraint(lhs, relationship, rhs);
+    }
+
+    @Test
+    public void testAbortAfterIterationWithLargeModel() {
+        final LargeModelFactory lmf = new LargeModelFactory();
+
+        final LinearObjectiveFunction f = new LinearObjectiveFunction(lmf.objective, 0);
+        f.getOptions().iterations_abort = 5;
+
+        final Collection<LinearConstraint> constraints = lmf.generateConstraints();
+
+        final SimplexSolver solver = new SimplexSolver();
+        final PointValuePair solution = solver.optimize(f, constraints, GoalType.MINIMIZE, true);
+        TestUtils.assertEquals(State.UNEXPLORED, solution.getState());
     }
 
 }


### PR DESCRIPTION
See #149; I simply followed the same procedure as in `IntegerSolver` and `ConvexSolver` by resetting the time and iteration counters and then checking whether the next iteration is allowed in the corresponding loop.

I did not create a test for this, because I wasn't quite sure how to test this properly. One idea would be to solve a large problem, setting a very short timeout like 100ms, and setting a JUnit timeout of 1s or similar (to avoid failing tests if preparation, etc. take longer on slow machines), but this would feel a little strange. I could still add this test if you think this is necessary/have another suggestion!