### PR TITLE
Update ActiveSetSolver.java

### DIFF
--- a/src/org/ojalgo/optimisation/convex/ActiveSetSolver.java
+++ b/src/org/ojalgo/optimisation/convex/ActiveSetSolver.java
@@ -522,8 +522,11 @@ abstract class ActiveSetSolver extends ConstrainedSolver {
             // At least 1 active inequality
 
             this.shrink();
-
-            this.performIteration();
+            
+            if (this.isIterationAllowed())
+                this.performIteration();
+            else
+                this.setState(State.FAILED);
 
         } else if (!this.isSolvableQ()) {
             // Subproblem NOT solved successfully
@@ -546,9 +549,12 @@ abstract class ActiveSetSolver extends ConstrainedSolver {
                 }
             });
 
-            this.resetActivator();
-
-            this.performIteration();
+            if (this.isIterationAllowed()) {
+                this.resetActivator();
+                this.performIteration();
+            }
+            else
+                this.setState(State.FAILED);
 
         } else if (this.checkFeasibility(false)) {
             // Subproblem NOT solved successfully, but current solution is feasible


### PR DESCRIPTION
enforce time_abort and iterations_abort in ConvextSolver Options for ActiveSetSolver, which is used by IterativeASS to solve Convex Optimization with inequality constraint. 
Solver iteration will NOT continue when iteration or time limit set in option is reached.
This avoid the case of long calculation time or dead loop.