### PR TITLE
Add a test of Lagrangian multipliers for ConvexSolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ojalgo</groupId>
     <artifactId>ojalgo</artifactId>
-    <version>48.3.0</version>
+    <version>48.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>ojAlgo</name>
     <url>http://ojalgo.org</url>

--- a/test/org/ojalgo/optimisation/convex/ConvexProblems.java
+++ b/test/org/ojalgo/optimisation/convex/ConvexProblems.java
@@ -1652,10 +1652,10 @@ public class ConvexProblems extends OptimisationConvexTests {
       Optional<Access1D<?>> multipliers = result.getMultipliers();
       TestUtils.assertTrue(" No multipliers present", multipliers.isPresent());
       Primitive64Store expectedDual = Primitive64Store.FACTORY.rows(new double[][]{
-         {3}, {-2}
+         {-3}, {2}
       });
-// [Q][x] - [A]<sup>T</sup>[L] = - [C]
-      MatrixStore<Double> computedC = Q.multiply(expectedX).subtract(AE.transpose().multiply(expectedDual)).negate();
+// [Q][x] + [A]<sup>T</sup>[L] = - [C]
+      MatrixStore<Double> computedC = Q.multiply(expectedX).add(AE.transpose().multiply(expectedDual)).negate();
       TestUtils.assertEquals(C, computedC, accuracy);
 // [A][x] = [b]
       MatrixStore<Double> computedB = AE.multiply(expectedX);

--- a/test/org/ojalgo/optimisation/convex/LagrangeTest.java
+++ b/test/org/ojalgo/optimisation/convex/LagrangeTest.java
@@ -80,6 +80,19 @@ public class LagrangeTest extends OptimisationConvexTests {
 
         TestUtils.assertEquals(inequalityX, inequalitySolution, accuracy);
         TestUtils.assertEquals(inequalityL, inequalityMultipliers, accuracy);
+
+        // The first constraint is active, and the second is not
+        // Setting the first as an equality constraint, and only the other as an
+        // inequality should give the same result.
+
+        ConvexSolver mixConstrainedSolver = ConvexSolver.getBuilder(mtrxQ, mtrxC).equalities(mtrxAI.logical().row(0).get(), mtrxBI.logical().row(0).get())
+                .inequalities(mtrxAI.logical().row(1).get(), mtrxBI.logical().row(1).get()).build();
+
+        Result mixSolution = mixConstrainedSolver.solve();
+        Access1D<?> mixMultipliers = mixSolution.getMultipliers().get();
+
+        TestUtils.assertEquals(inequalityX, mixSolution, accuracy);
+        TestUtils.assertEquals(inequalityL, mixMultipliers, accuracy);
     }
 
     /**

--- a/test/org/ojalgo/optimisation/convex/LagrangeTest.java
+++ b/test/org/ojalgo/optimisation/convex/LagrangeTest.java
@@ -131,7 +131,7 @@ public class LagrangeTest extends OptimisationConvexTests {
         MatrixStore<Double> computedB = AE.multiply(expectedX);
         TestUtils.assertEquals(BE, computedB, accuracy);
 
-        // [Q][x] - [A]<sup>T</sup>[L] = - [C]
+        // [Q][x] + [A]<sup>T</sup>[L] = - [C]
         MatrixStore<Double> computedC = Q.multiply(expectedX).add(AE.transpose().multiply(expectedDual)).negate();
         TestUtils.assertEquals(C, computedC, accuracy);
 


### PR DESCRIPTION
This test assert that an equality constrained quadratic program solution return the right multipliers.

All but the last assertion in this test file pass, with present getMultipliers code.
The calculations in the end of the test convinced me that this is the right test, and that the multipliers got the wrong sign.