### PR TITLE
Add the ability to stop the optimization of a GenericSolver with Thread.interrupt()

### DIFF
--- a/src/org/ojalgo/optimisation/GenericSolver.java
+++ b/src/org/ojalgo/optimisation/GenericSolver.java
@@ -335,6 +335,10 @@ public abstract class GenericSolver implements Optimisation.Solver {
             return false;
         }
 
+        if (Thread.currentThread().isInterrupted()) {
+            return false;
+        }
+
         if (myState.isFeasible()) {
             return (this.countTime() < options.time_suffice) && (this.countIterations() < options.iterations_suffice);
         }

--- a/test/org/ojalgo/optimisation/linear/InterruptionTest.java
+++ b/test/org/ojalgo/optimisation/linear/InterruptionTest.java
@@ -1,0 +1,64 @@
+package org.ojalgo.optimisation.linear;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.ojalgo.optimisation.ExpressionsBasedModel;
+import org.ojalgo.optimisation.ModelFileMPS;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public class InterruptionTest {
+
+    public static final int TIMEOUT_DURATION = 4;
+
+    @Test
+    @Timeout(value = TIMEOUT_DURATION,unit = TimeUnit.SECONDS)
+    void slowMinimizationShouldBeInterrupted() throws InterruptedException {
+        final Thread minimizer = new Thread(this::launchSlowMinimization);
+        final Thread interrupter = new Thread(new ThreadInterrupter(minimizer));
+
+        minimizer.start();
+        interrupter.start();
+
+        minimizer.join();
+    }
+
+    @Test
+    void slowMinimisationShouldBeSlow() throws InterruptedException {
+        final Thread minimizer = new Thread(this::launchSlowMinimization);
+
+        minimizer.start();
+        minimizer.join(TIMEOUT_DURATION*1_000);
+        Assertions.assertTrue(minimizer.isAlive());
+
+        minimizer.interrupt();
+    }
+
+
+    private void launchSlowMinimization() {
+        final ExpressionsBasedModel model = ModelFileMPS.makeModel("netlib", "25FV47.SIF", false);
+        model.minimise();
+    }
+
+
+    private static class ThreadInterrupter implements Runnable {
+
+        private final Thread threadToInterrupt;
+
+        public ThreadInterrupter(Thread threadToInterrupt) {
+            this.threadToInterrupt = Objects.requireNonNull(threadToInterrupt);
+        }
+
+        @Override
+        public void run() {
+            try {
+                Thread.sleep(TIMEOUT_DURATION*500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            threadToInterrupt.interrupt();
+        }
+    }
+}


### PR DESCRIPTION
There are some mechanisms to stop an optimization but they have to be setup before the optimization is launched (like the maximal number of iterations) but there is not mechanism to stop a minimization on request.

This PR add the possibility to do so by using the thread interruption mechanism.
