### PR TITLE
Amend EBM parser to handle empty lines and comments

### DIFF
--- a/src/main/java/org/ojalgo/optimisation/FileFormatEBM.java
+++ b/src/main/java/org/ojalgo/optimisation/FileFormatEBM.java
@@ -38,6 +38,7 @@ import org.ojalgo.structure.Structure2D.IntRowColumn;
 abstract class FileFormatEBM {
 
     private static final String TAB = String.valueOf(ASCII.HT);
+    private static final String COMMENT = "*";
 
     private static Expression readExpression(final ExpressionsBasedModel model, final String[] fields) {
 
@@ -176,6 +177,11 @@ abstract class FileFormatEBM {
             while ((line = reader.readLine()) != null) {
 
                 String[] fields = line.split(TAB);
+
+                if (line.isBlank() || line.startsWith(COMMENT)) {
+                    // Skip this line
+                    continue;
+                }
 
                 switch (line.charAt(0)) {
                     case 'V':

--- a/src/test/java/org/ojalgo/optimisation/FileFormatEBMTest.java
+++ b/src/test/java/org/ojalgo/optimisation/FileFormatEBMTest.java
@@ -1,0 +1,24 @@
+package org.ojalgo.optimisation;
+
+import org.junit.jupiter.api.Test;
+import org.ojalgo.TestUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+class FileFormatEBMTest {
+
+    @Test
+    void testEBMParserWithEmptyLinesAndComments() {
+        try (InputStream input = ExpressionsBasedModel.class.getResourceAsStream("/comment.ebm")) {
+            TestUtils.assertTrue(input != null);
+            ExpressionsBasedModel model = ExpressionsBasedModel.parse(input, ExpressionsBasedModel.FileFormat.EBM);
+            Optimisation.Result result = model.minimise();
+            TestUtils.assertTrue(result.getState().isSuccess());
+            TestUtils.assertEquals(2, result.getValue(), 1e-12);
+        } catch (IOException cause) {
+            TestUtils.fail(cause);
+        }
+    }
+
+}

--- a/src/test/resources/comment.ebm
+++ b/src/test/resources/comment.ebm
@@ -1,0 +1,5 @@
+V	v1	2	2	1	false	2
+
+
+
+* a test file containing a tiny model, an empty line, a blank line, a line with a tab and this comment after a '*'


### PR DESCRIPTION
**Description**
I find it nice to be able to describe an EBM model in the EBM file itself. This patch implement this possibility and also allow for empty lines and blank lines in EBM files.

**Test Cases**
Patch add a tiny EBM model with a comment and a few blank lines. It also adds a test which parse and optimize this model, and assert its result.
