### PR TITLE
Divide angle by 2 when making rotation

### DIFF
--- a/src/main/java/org/ojalgo/scalar/Quaternion.java
+++ b/src/main/java/org/ojalgo/scalar/Quaternion.java
@@ -173,7 +173,8 @@ public final class Quaternion implements SelfDeclaringScalar<Quaternion>, Access
 
     public static Quaternion makeRotation(final RotationAxis axis, final double angle) {
 
-        final double tmpScalar = PrimitiveMath.COS.invoke(angle);
+        final double tmpHalfAngle = PrimitiveMath.DIVIDE.invoke(angle, 2);
+        final double tmpScalar = PrimitiveMath.COS.invoke(tmpHalfAngle);
 
         double tmpI = PrimitiveMath.ZERO;
         double tmpJ = PrimitiveMath.ZERO;
@@ -183,17 +184,17 @@ public final class Quaternion implements SelfDeclaringScalar<Quaternion>, Access
 
             case X:
 
-                tmpI = PrimitiveMath.SIN.invoke(angle);
+                tmpI = PrimitiveMath.SIN.invoke(tmpHalfAngle);
                 break;
 
             case Y:
 
-                tmpJ = PrimitiveMath.SIN.invoke(angle);
+                tmpJ = PrimitiveMath.SIN.invoke(tmpHalfAngle);
                 break;
 
             case Z:
 
-                tmpK = PrimitiveMath.SIN.invoke(angle);
+                tmpK = PrimitiveMath.SIN.invoke(tmpHalfAngle);
                 break;
 
             default:

--- a/src/main/java/org/ojalgo/scalar/Quaternion.java
+++ b/src/main/java/org/ojalgo/scalar/Quaternion.java
@@ -171,6 +171,28 @@ public final class Quaternion implements SelfDeclaringScalar<Quaternion>, Access
 
     }
 
+    /**
+     * Create a {@link Quaternion} that captures a rotation about the provided axis by the provided
+     * angle.
+     * <p>
+     * The quaternion representation of the rotation may be expressed as:
+     * <pre>q = cos(θ / 2) + sin(θ / 2) * (ub * i + uc * j + ud * k)</pre>
+     * where θ is the angle of rotation and <pre>[ub, uc, ud]</pre> is the axis of rotation.  This
+     * method accepts a single axis, so only a single imaginary component is populated.
+     * <p>
+     * To rotate in multiple axes, multiply multiple quaternions:
+     * <pre>{@code
+     * Quaternion xRotation = Quaternion.makeRotation(RotationAxis.X, Math.toRadians(-3));
+     * Quaternion yRotation = Quaternion.makeRotation(RotationAxis.Y, Math.toRadians(2));
+     * Quaternion zRotation = Quaternion.makeRotation(RotationAxis.Z, Math.toRadians(45));
+     * Quaternion zyxRotation = zRotation.multiply(yRotation).multiply(xRotation);
+     * }</pre>
+     * This creates a rotation in ZYX order.
+     *
+     * @param axis  the axis to rotate about, non-null
+     * @param angle the angle, in radians to rotate about the axis
+     * @return the quaternion
+     */    
     public static Quaternion makeRotation(final RotationAxis axis, final double angle) {
 
         final double tmpHalfAngle = PrimitiveMath.DIVIDE.invoke(angle, 2);

--- a/src/test/java/org/ojalgo/scalar/QuaternionTest.java
+++ b/src/test/java/org/ojalgo/scalar/QuaternionTest.java
@@ -132,4 +132,35 @@ public class QuaternionTest extends ScalarTests {
 
     }
 
+    @Test
+    public void testMakeRotation() {
+        // from MATLAB:
+        // >> expected = quaternion([0 deg2rad(-20) 0], "rotvec")
+        // expected =
+        //   quaternion
+        //      0.98481 +       0i - 0.17365j +       0k
+
+        double angle = Math.toRadians(-20);
+        double expectedScalar = 0.98481;
+        double expectedImaginary = -0.17365;
+
+        Quaternion actualX = Quaternion.makeRotation(RotationAxis.X, angle);
+        TestUtils.assertEquals(expectedScalar, actualX.scalar(), 1e-5);
+        TestUtils.assertEquals(expectedImaginary, actualX.i, 1e-5);
+        TestUtils.assertEquals(0, actualX.j, 1e-5);
+        TestUtils.assertEquals(0, actualX.k, 1e-5);
+
+        Quaternion actualY = Quaternion.makeRotation(RotationAxis.Y, angle);
+        TestUtils.assertEquals(expectedScalar, actualY.scalar(), 1e-5);
+        TestUtils.assertEquals(0, actualY.i, 1e-5);
+        TestUtils.assertEquals(expectedImaginary, actualY.j, 1e-5);
+        TestUtils.assertEquals(0, actualY.k, 1e-5);
+
+        Quaternion actualZ = Quaternion.makeRotation(RotationAxis.Z, angle);
+        TestUtils.assertEquals(expectedScalar, actualZ.scalar(), 1e-5);
+        TestUtils.assertEquals(0, actualZ.i, 1e-5);
+        TestUtils.assertEquals(0, actualZ.j, 1e-5);
+        TestUtils.assertEquals(expectedImaginary, actualZ.k, 1e-5);
+    }
+    
 }

--- a/src/test/java/org/ojalgo/scalar/QuaternionTest.java
+++ b/src/test/java/org/ojalgo/scalar/QuaternionTest.java
@@ -28,6 +28,7 @@ import org.ojalgo.function.constant.QuaternionMath;
 import org.ojalgo.matrix.store.MatrixStore;
 import org.ojalgo.matrix.store.PhysicalStore;
 import org.ojalgo.matrix.store.RawStore;
+import org.ojalgo.scalar.Quaternion.RotationAxis;
 
 public class QuaternionTest extends ScalarTests {
 
@@ -55,6 +56,37 @@ public class QuaternionTest extends ScalarTests {
                 }
             }
         }
+    }
+
+    @Test
+    public void testMakeRotation() {
+        // from MATLAB:
+        // >> expected = quaternion([0 deg2rad(-20) 0], "rotvec")
+        // expected =
+        // quaternion
+        // 0.98481 + 0i - 0.17365j + 0k
+
+        double angle = Math.toRadians(-20);
+        double expectedScalar = 0.98481;
+        double expectedImaginary = -0.17365;
+
+        Quaternion actualX = Quaternion.makeRotation(RotationAxis.X, angle);
+        TestUtils.assertEquals(expectedScalar, actualX.scalar(), 1e-5);
+        TestUtils.assertEquals(expectedImaginary, actualX.i, 1e-5);
+        TestUtils.assertEquals(0, actualX.j, 1e-5);
+        TestUtils.assertEquals(0, actualX.k, 1e-5);
+
+        Quaternion actualY = Quaternion.makeRotation(RotationAxis.Y, angle);
+        TestUtils.assertEquals(expectedScalar, actualY.scalar(), 1e-5);
+        TestUtils.assertEquals(0, actualY.i, 1e-5);
+        TestUtils.assertEquals(expectedImaginary, actualY.j, 1e-5);
+        TestUtils.assertEquals(0, actualY.k, 1e-5);
+
+        Quaternion actualZ = Quaternion.makeRotation(RotationAxis.Z, angle);
+        TestUtils.assertEquals(expectedScalar, actualZ.scalar(), 1e-5);
+        TestUtils.assertEquals(0, actualZ.i, 1e-5);
+        TestUtils.assertEquals(0, actualZ.j, 1e-5);
+        TestUtils.assertEquals(expectedImaginary, actualZ.k, 1e-5);
     }
 
     @Test
@@ -132,35 +164,4 @@ public class QuaternionTest extends ScalarTests {
 
     }
 
-    @Test
-    public void testMakeRotation() {
-        // from MATLAB:
-        // >> expected = quaternion([0 deg2rad(-20) 0], "rotvec")
-        // expected =
-        //   quaternion
-        //      0.98481 +       0i - 0.17365j +       0k
-
-        double angle = Math.toRadians(-20);
-        double expectedScalar = 0.98481;
-        double expectedImaginary = -0.17365;
-
-        Quaternion actualX = Quaternion.makeRotation(RotationAxis.X, angle);
-        TestUtils.assertEquals(expectedScalar, actualX.scalar(), 1e-5);
-        TestUtils.assertEquals(expectedImaginary, actualX.i, 1e-5);
-        TestUtils.assertEquals(0, actualX.j, 1e-5);
-        TestUtils.assertEquals(0, actualX.k, 1e-5);
-
-        Quaternion actualY = Quaternion.makeRotation(RotationAxis.Y, angle);
-        TestUtils.assertEquals(expectedScalar, actualY.scalar(), 1e-5);
-        TestUtils.assertEquals(0, actualY.i, 1e-5);
-        TestUtils.assertEquals(expectedImaginary, actualY.j, 1e-5);
-        TestUtils.assertEquals(0, actualY.k, 1e-5);
-
-        Quaternion actualZ = Quaternion.makeRotation(RotationAxis.Z, angle);
-        TestUtils.assertEquals(expectedScalar, actualZ.scalar(), 1e-5);
-        TestUtils.assertEquals(0, actualZ.i, 1e-5);
-        TestUtils.assertEquals(0, actualZ.j, 1e-5);
-        TestUtils.assertEquals(expectedImaginary, actualZ.k, 1e-5);
-    }
-    
 }


### PR DESCRIPTION
**Describe the PR**
Divide the input angle by two when computing a quaternion for a rotation.

**Test Cases**
No test case existed.
