### PR TITLE
optional activation

### DIFF
--- a/src/main/java/org/ojalgo/optimisation/convex/IterativeASS.java
+++ b/src/main/java/org/ojalgo/optimisation/convex/IterativeASS.java
@@ -304,9 +304,9 @@ final class IterativeASS extends ActiveSetSolver {
     }
 
     @Override
-    void resetActivator() {
+    void resetActivator(boolean activate) {
 
-        super.resetActivator();
+        super.resetActivator(activate);
 
         int nbEqus = this.countEqualityConstraints();
         int nbVars = this.countVariables();


### PR DESCRIPTION
@Programmer-Magnus 

You mentioned once that you had a problem with the QP solver initiating itself with a lot of inequalities active, and then spending time deactivating those, to eventually return a solution with no or very few inequalities active. I assume this is when using `extendedPrecision` and the `IterativeRefinementSolver`. Can you test if this small change makes a difference in your case?