### PR TITLE
Run junit tests in parallel

### DIFF
--- a/src/test/java/org/ojalgo/optimisation/linear/CuteNetlibCase.java
+++ b/src/test/java/org/ojalgo/optimisation/linear/CuteNetlibCase.java
@@ -23,6 +23,8 @@ package org.ojalgo.optimisation.linear;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.ojalgo.optimisation.ExpressionsBasedModel;
 import org.ojalgo.optimisation.ModelFileTest;
 import org.ojalgo.type.context.NumberContext;
@@ -40,10 +42,10 @@ import org.ojalgo.type.context.NumberContext;
  *
  * @author apete
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class CuteNetlibCase extends OptimisationLinearTests implements ModelFileTest {
 
     private static void doTest(final String name, final String expMinValString, final String expMaxValString, final NumberContext accuracy) {
-
         ExpressionsBasedModel model = ModelFileTest.makeModel("netlib", name, false);
 
         // model.options.debug(Optimisation.Solver.class);

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=same_thread
+junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.config.dynamic.factor=0.5


### PR DESCRIPTION
This PR shows how junit can use many cores and threads to run tests in parallel. This make running tests use less wall clock time. This should not be added to benchmarks, because their result are affected by running in parallel.

The relevant junit settings are located in the added file junit-platform.properties.
Present settings let tests use at most half of the available cores while running in parallel. 
The present default for classes are to run in one thread (default=SAME_THREAD in properties file). 
The annotation `@Execution(ExecutionMode.CONCURRENT)` was added to CuteNetlibCase.java as an example of how to enable parallel run when it is not on by default. It is possible to make running in parallel the default for all classes by setting default=CONCURRENT in properties file. 

If running tests in parallel is a good idea, then the above annotation can be added to all none benchmark tests. 
And the properties in the properties file can be modified to suit the project better.

junit documentation:
https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-parallel-execution