### PR TITLE
Configure ConvexSolver to use QMR

### DIFF
--- a/src/main/java/org/ojalgo/matrix/task/iterative/ConjugateGradientSolver.java
+++ b/src/main/java/org/ojalgo/matrix/task/iterative/ConjugateGradientSolver.java
@@ -145,16 +145,6 @@ public final class ConjugateGradientSolver extends KrylovSubspaceSolver implemen
         return normErr / normRHS;
     }
 
-    @Override
-    public MatrixStore<Double> solve(final Access2D<?> body, final Access2D<?> rhs, final PhysicalStore<Double> preallocated) throws RecoverableCondition {
-
-        List<Equation> equations = IterativeSolverTask.toListOfRows(body, rhs);
-
-        this.resolve(equations, preallocated);
-
-        return preallocated;
-    }
-
     private R064Store direction(final Structure1D structure) {
         if (myDirection == null || myDirection.count() != structure.count()) {
             myDirection = R064Store.FACTORY.make(structure.count(), 1L);

--- a/src/main/java/org/ojalgo/matrix/task/iterative/GaussSeidelSolver.java
+++ b/src/main/java/org/ojalgo/matrix/task/iterative/GaussSeidelSolver.java
@@ -81,13 +81,5 @@ public final class GaussSeidelSolver extends StationaryIterativeSolver implement
         return tmpNormErr / tmpNormRHS;
     }
 
-    public MatrixStore<Double> solve(final Access2D<?> body, final Access2D<?> rhs, final PhysicalStore<Double> current) throws RecoverableCondition {
-
-        final List<Equation> equations = IterativeSolverTask.toListOfRows(body, rhs);
-
-        this.resolve(equations, current);
-
-        return current;
-    }
 
 }

--- a/src/main/java/org/ojalgo/matrix/task/iterative/IterativeSolverTask.java
+++ b/src/main/java/org/ojalgo/matrix/task/iterative/IterativeSolverTask.java
@@ -94,7 +94,7 @@ public abstract class IterativeSolverTask implements SolverTask<Double> {
 
     }
 
-    public interface SparseDelegate {
+    public interface SparseDelegate extends SolverTask<Double>{
 
         double resolve(List<Equation> equations, PhysicalStore<Double> solution);
 
@@ -111,6 +111,15 @@ public abstract class IterativeSolverTask implements SolverTask<Double> {
             }
 
             return this.resolve(equations, solution);
+        }
+
+        default MatrixStore<Double> solve(final Access2D<?> body, final Access2D<?> rhs, final PhysicalStore<Double> preallocated) throws RecoverableCondition {
+
+            List<Equation> equations = IterativeSolverTask.toListOfRows(body, rhs);
+
+            this.resolve(equations, preallocated);
+
+            return preallocated;
         }
 
     }

--- a/src/main/java/org/ojalgo/matrix/task/iterative/MutableSolver.java
+++ b/src/main/java/org/ojalgo/matrix/task/iterative/MutableSolver.java
@@ -39,7 +39,7 @@ import org.ojalgo.type.context.NumberContext;
  *
  * @author apete
  */
-public abstract class MutableSolver<D extends IterativeSolverTask & IterativeSolverTask.SparseDelegate> extends IterativeSolverTask {
+public abstract class MutableSolver<D extends IterativeSolverTask.SparseDelegate> extends IterativeSolverTask {
 
     private final D myDelegate;
     private final List<Equation> myRows = new ArrayList<>();
@@ -109,19 +109,25 @@ public abstract class MutableSolver<D extends IterativeSolverTask & IterativeSol
     @Override
     protected void setAccuracyContext(final NumberContext accuracyContext) {
         super.setAccuracyContext(accuracyContext);
-        myDelegate.setAccuracyContext(accuracyContext);
+        if (myDelegate instanceof IterativeSolverTask) {
+            ((IterativeSolverTask) myDelegate).setAccuracyContext(accuracyContext);
+        }
     }
 
     @Override
     protected void setDebugPrinter(final BasicLogger debugPrinter) {
         super.setDebugPrinter(debugPrinter);
-        myDelegate.setDebugPrinter(debugPrinter);
+        if (myDelegate instanceof IterativeSolverTask) {
+            ((IterativeSolverTask) myDelegate).setDebugPrinter(debugPrinter);
+        }
     }
 
     @Override
     protected void setIterationsLimit(final int iterationsLimit) {
         super.setIterationsLimit(iterationsLimit);
-        myDelegate.setIterationsLimit(iterationsLimit);
+        if (myDelegate instanceof IterativeSolverTask) {
+            ((IterativeSolverTask) myDelegate).setIterationsLimit(iterationsLimit);
+        }
     }
 
 }

--- a/src/main/java/org/ojalgo/matrix/task/iterative/ParallelGaussSeidelSolver.java
+++ b/src/main/java/org/ojalgo/matrix/task/iterative/ParallelGaussSeidelSolver.java
@@ -72,16 +72,6 @@ public final class ParallelGaussSeidelSolver extends StationaryIterativeSolver i
         return this.resolve(equations, solution, normRHS, iterationsCounter, 0, nbEquations);
     }
 
-    @Override
-    public MatrixStore<Double> solve(final Access2D<?> body, final Access2D<?> rhs, final PhysicalStore<Double> current) throws RecoverableCondition {
-
-        List<Equation> equations = IterativeSolverTask.toListOfRows(body, rhs);
-
-        this.resolve(equations, current);
-
-        return current;
-    }
-
     private double resolve(final List<Equation> equations, final PhysicalStore<Double> solution, final double normRHS, final AtomicInteger iterationsCounter,
             final int first, final int last) {
 

--- a/src/main/java/org/ojalgo/optimisation/convex/ConvexSolver.java
+++ b/src/main/java/org/ojalgo/optimisation/convex/ConvexSolver.java
@@ -44,6 +44,7 @@ import org.ojalgo.matrix.store.MatrixStore;
 import org.ojalgo.matrix.store.PhysicalStore;
 import org.ojalgo.matrix.store.R064Store;
 import org.ojalgo.matrix.task.iterative.ConjugateGradientSolver;
+import org.ojalgo.matrix.task.iterative.IterativeSolverTask.SparseDelegate;
 import org.ojalgo.optimisation.Expression;
 import org.ojalgo.optimisation.ExpressionsBasedModel;
 import org.ojalgo.optimisation.GenericSolver;
@@ -366,6 +367,7 @@ public abstract class ConvexSolver extends GenericSolver {
         private boolean myCombinedScaleFactor = true;
         private boolean myExtendedPrecision = false;
         private NumberContext myIterative = NumberContext.of(10, 14).withMode(RoundingMode.HALF_DOWN);
+        private SparseDelegate myIterativeSolver = new ConjugateGradientSolver();
         private double mySmallDiagonal = RELATIVELY_SMALL + MACHINE_EPSILON;
         private Function<Structure2D, MatrixDecomposition.Solver<Double>> mySolverGeneral = LU.R064::make;
         private Function<Structure2D, MatrixDecomposition.Solver<Double>> mySolverSPD = Cholesky.R064::make;
@@ -426,6 +428,21 @@ public abstract class ConvexSolver extends GenericSolver {
             Objects.requireNonNull(accuracy);
             myIterative = accuracy;
             return this;
+        }
+
+        /**
+         * Select which iterative linear system solver to use for the Schur-complement step in IterativeASS.
+         * Default is {@link ConjugateGradientSolver}. You may set e.g. new {@code QMRSolver()}.
+         */
+        public Configuration setIterativeSolver(final SparseDelegate solver) {
+            Objects.requireNonNull(solver);
+            myIterativeSolver = solver;
+            return this;
+        }
+
+        /** Returns the configured iterative solver */
+        public SparseDelegate getIterativeSolver() {
+            return myIterativeSolver;
         }
 
         public MatrixDecomposition.Solver<Double> newSolverGeneral(final Structure2D structure) {

--- a/src/main/java/org/ojalgo/optimisation/convex/IterativeASS.java
+++ b/src/main/java/org/ojalgo/optimisation/convex/IterativeASS.java
@@ -34,7 +34,7 @@ import org.ojalgo.matrix.store.ElementsSupplier;
 import org.ojalgo.matrix.store.MatrixStore;
 import org.ojalgo.matrix.store.PhysicalStore;
 import org.ojalgo.matrix.store.R064Store;
-import org.ojalgo.matrix.task.iterative.ConjugateGradientSolver;
+import org.ojalgo.matrix.task.iterative.IterativeSolverTask;
 import org.ojalgo.matrix.task.iterative.MutableSolver;
 import org.ojalgo.optimisation.Optimisation;
 import org.ojalgo.scalar.PrimitiveScalar;
@@ -60,7 +60,7 @@ final class IterativeASS extends ActiveSetSolver {
      *
      * @author apete
      */
-    final class SchurComplementSolver extends MutableSolver<ConjugateGradientSolver> implements MatrixStore<Double> {
+    final class SchurComplementSolver extends MutableSolver<IterativeSolverTask.SparseDelegate> implements MatrixStore<Double> {
 
         private final int myCountE = IterativeASS.this.countEqualityConstraints();
         private final SparseArrayPool myEquationBodyPool;
@@ -69,7 +69,7 @@ final class IterativeASS extends ActiveSetSolver {
 
         SchurComplementSolver() {
 
-            super(new ConjugateGradientSolver(), IterativeASS.this.countEqualityConstraints() + IterativeASS.this.countInequalityConstraints());
+            super(options.convex().getIterativeSolver(), IterativeASS.this.countEqualityConstraints() + IterativeASS.this.countInequalityConstraints());
 
             // GaussSeidel
             //this.setTerminationContext(NumberContext.getMath(MathContext.DECIMAL64).newPrecision(13));


### PR DESCRIPTION
This patch modify code to allow ConvexSolver to use QMRSolver in IterativeASS.
Had to modify types to make it compile, might be better ways I did not find. But patch is quite small.

After making it possible to select `QMRSolver ` instead of `ConjugateGradientSolver` with:
`      ConvexSolver.Configuration convex = SolverUtils.OPTIONS.convex().setIterativeSolver(new QMRSolver());`
 
I found that Equation.dot(R064Store) sometimes give out of bounds error (`ArrayIndexOutOfBoundsException`), but R064Store.dot(Equation) do not.
So there is a patch for this as well in this PR, switching order around `dot`. But I din not manage to solve a similar out of bounds error in the double loop following:
           ` // ATq = A^T * q (dense accumulation from rows)`
This does not happen the first `solve` , but when I reuse a `ConvexSolver` model setting new start values and solve it again.
This works with `ConjugateGradientSolver` so something is not well in the QMRSolver.

Summary of questions:
Is there a better way to make the SchurComplementSolver be able to use either QMRSolver or ConjugateGradientSolver?
Do `Equation` have a problem used with SparseArrays or do I use them wrong?
Should it work to do Equation.dot(R064Store) ?
