### PR TITLE
Changed getDenominator and getNumerator to public

### DIFF
--- a/src/main/java/org/ojalgo/scalar/RationalNumber.java
+++ b/src/main/java/org/ojalgo/scalar/RationalNumber.java
@@ -721,11 +721,11 @@ public final class RationalNumber implements SelfDeclaringScalar<RationalNumber>
         }
     }
 
-    long getDenominator() {
+    public long getDenominator() {
         return myDenominator;
     }
 
-    long getNumerator() {
+    public long getNumerator() {
         return myNumerator;
     }
 


### PR DESCRIPTION
Set the methods getNumerator and getDenominator of the RationalNumber class to public.

Directly addresses issue #659.
