### PR TITLE
ModelFileTest.java: Double the optimisation solver time_suffice from 5 to 10 minutes

### DIFF
--- a/src/test/java/org/ojalgo/optimisation/ModelFileTest.java
+++ b/src/test/java/org/ojalgo/optimisation/ModelFileTest.java
@@ -133,7 +133,7 @@ public interface ModelFileTest {
                 }
             }
 
-            model.options.time_suffice = 5L * CalendarDateUnit.MINUTE.toDurationInMillis();
+            model.options.time_suffice = 10L * CalendarDateUnit.MINUTE.toDurationInMillis();
             model.options.time_abort = 15L * CalendarDateUnit.MINUTE.toDurationInMillis();
 
             TestUtils.assertTrue(model.validate());


### PR DESCRIPTION
The solver timeout for test models was set to 5 minutes (300s), which causes test failures on single-CPU systems where thread over-subscription in the MIP solver (5 worker threads on 1 core) slows convergence. On such systems the solver reaches a feasible solution within 300s but does not yet prove optimality, triggering a premature stop via time_suffice.

Doubling the limit to 10 minutes gives single-CPU builds enough time to converge, while having no impact on multi-CPU builds where the solver already finishes well before the timeout.

Should fix https://github.com/optimatika/ojAlgo/issues/670