### PR TITLE
fix: correct typos in JavaDoc comments (suceeded→succeeded, paramaters→parameters)

### DIFF
--- a/src/main/java/org/ojalgo/matrix/decomposition/MatrixDecomposition.java
+++ b/src/main/java/org/ojalgo/matrix/decomposition/MatrixDecomposition.java
@@ -317,7 +317,7 @@ public interface MatrixDecomposition<N extends Comparable<N>> extends Structure2
 
         /**
          * @param matrix A matrix to decompose
-         * @return true if the decomposition suceeded AND {@link #isSolvable()}; false if not
+         * @return true if the decomposition succeeded AND {@link #isSolvable()}; false if not
          */
         default boolean compute(final Access2D.Collectable<N, ? super TransformableRegion<N>> matrix) {
             return this.decompose(matrix) && this.isSolvable();
@@ -498,7 +498,7 @@ public interface MatrixDecomposition<N extends Comparable<N>> extends Structure2
 
     /**
      * @param matrix A matrix to decompose
-     * @return true if decomposition suceeded; false if not
+     * @return true if decomposition succeeded; false if not
      */
     boolean decompose(Access2D.Collectable<N, ? super TransformableRegion<N>> matrix);
 

--- a/src/main/java/org/ojalgo/random/scedasticity/ARCH.java
+++ b/src/main/java/org/ojalgo/random/scedasticity/ARCH.java
@@ -77,7 +77,7 @@ public final class ARCH extends AbstractScedasticity {
 
     /**
      * Will create an instance configured with default parameters. What these are may change in the future.
-     * You're better of estimating suitable paramaters for your use case and then set {@link #base(double)}
+     * You're better of estimating suitable parameters for your use case and then set {@link #base(double)}
      * and {@link #errorWeights(double...)}.
      */
     public static ARCH newInstance(final int q, final double mean, final double variance) {

--- a/src/main/java/org/ojalgo/random/scedasticity/GARCH.java
+++ b/src/main/java/org/ojalgo/random/scedasticity/GARCH.java
@@ -82,7 +82,7 @@ public final class GARCH extends AbstractScedasticity {
 
     /**
      * Will create an instance configured with default parameters. What these are may change in the future.
-     * You're better of estimating suitable paramaters for your use case and then set {@link #base(double)},
+     * You're better of estimating suitable parameters for your use case and then set {@link #base(double)},
      * {@link #errorWeights(double...)} and {@link #varianceWeights(double...)}.
      */
     public static GARCH newInstance(final int p, final int q, final double mean, final double variance) {


### PR DESCRIPTION
## Summary
Corrected 4 typos in JavaDoc comments across 3 files:

- `MatrixDecomposition.java`: `suceeded` → `succeeded` (2 instances in @return javadoc)
- `GARCH.java`: `paramaters` → `parameters` (1 instance)
- `ARCH.java`: `paramaters` → `parameters` (1 instance)

## Files Changed
- `src/main/java/org/ojalgo/matrix/decomposition/MatrixDecomposition.java`
- `src/main/java/org/ojalgo/random/scedasticity/GARCH.java`
- `src/main/java/org/ojalgo/random/scedasticity/ARCH.java`

## Verification
- 3 files changed, 4 insertions(+), 4 deletions(-)
- No functional code changes
- Single commit with GH007 compliant email